### PR TITLE
Add historical image source captions to lightbox

### DIFF
--- a/src/components/GLightbox.astro
+++ b/src/components/GLightbox.astro
@@ -6,6 +6,26 @@
   import GLightbox from 'glightbox';
   import 'glightbox/dist/css/glightbox.min.css';
 
+  const escapeHtml = (str: string) =>
+    str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const buildSourceDescription = (link: HTMLAnchorElement) => {
+    const isHistorical = link.dataset.historical === 'true';
+    const source = link.dataset.source?.trim();
+
+    if (!isHistorical || !source) {
+      return '';
+    }
+
+    const sourceUrl = link.dataset.sourceUrl?.trim();
+    return sourceUrl ? `Source: ${source} (${sourceUrl})` : `Source: ${source}`;
+  };
+
   function syncLightboxCaptions(root = document) {
     const links = Array.from(
       root.querySelectorAll<HTMLAnchorElement>('a.glightbox')
@@ -35,6 +55,27 @@
             visibleCaption.textContent = titleMatch[1].trim();
           }
         }
+      }
+
+      // Ensure historical image sources are reflected in GLightbox metadata
+      const sourceDescription = buildSourceDescription(link);
+      if (sourceDescription) {
+        const glightboxAttr = link.dataset.glightbox || '';
+        const sanitizedDescription = escapeHtml(sourceDescription);
+
+        if (/description:\s*/.test(glightboxAttr)) {
+          link.dataset.glightbox = glightboxAttr.replace(
+            /description:\s*([^;]*)(;|$)/,
+            `description: ${sanitizedDescription}$2`
+          );
+        } else if (glightboxAttr) {
+          link.dataset.glightbox = `${glightboxAttr}; description: ${sanitizedDescription}`;
+        } else {
+          link.dataset.glightbox = `description: ${sanitizedDescription}`;
+        }
+
+        // Provide fallback for GLightbox's native data-description parsing
+        link.dataset.description = sourceDescription;
       }
 
       // Set SEO alt text on images

--- a/src/components/GalleryLightbox.astro
+++ b/src/components/GalleryLightbox.astro
@@ -86,6 +86,7 @@ const resolvedImages = images.map(image => {
     seoCaption: image.seoCaption,
     sourceurl: image.sourceurl,
     source: image.source,
+    historical: Boolean(image.historical),
     position: image.position,
     metadata,
     resolvedAspect,
@@ -93,18 +94,32 @@ const resolvedImages = images.map(image => {
 });
 ---
 <div class={className} data-no-anchor={noAnchor ? "true" : undefined}>
-  {resolvedImages.map(({ metadata, caption, seoCaption, resolvedAspect, sourceurl, source, position }, index) => {
+  {resolvedImages.map(({ metadata, caption, seoCaption, resolvedAspect, sourceurl, source, position, historical }, index) => {
     const finalCaption = caption ?? "";
     const finalSeoCaption = seoCaption || finalCaption || `Gallery image ${index + 1}`;
     const Tag = (noAnchor ? "div" : "a") as "div" | "a";
     const baseClass = "gallery-item" + (noAnchor ? "" : " glightbox");
     // Build GLightbox description string (escape HTML entities to prevent breaking attributes)
-    const escapeHtml = (str: string) => str.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    const escapeHtml = (str: string) =>
+      str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
     let glightboxDesc = "";
     if (finalCaption) glightboxDesc += `title: ${escapeHtml(finalCaption)}`;
-    if (source) {
+    const trimmedSource = source?.trim() || "";
+    const trimmedSourceUrl = sourceurl?.trim() || "";
+    const isHistorical = Boolean(historical);
+    const hasSource = trimmedSource.length > 0;
+    const shouldShowSource = isHistorical && hasSource;
+    const descriptionText = shouldShowSource
+      ? `Source: ${trimmedSource}${trimmedSourceUrl ? ` (${trimmedSourceUrl})` : ""}`
+      : "";
+    if (descriptionText) {
       if (glightboxDesc) glightboxDesc += "; ";
-      glightboxDesc += `description: ${escapeHtml(source)}`;
+      glightboxDesc += `description: ${escapeHtml(descriptionText)}`;
     }
 
     const interactiveProps = noAnchor
@@ -113,7 +128,10 @@ const resolvedImages = images.map(image => {
           href: metadata.src,
           "data-gallery": galleryId,
           "data-glightbox": glightboxDesc || undefined,
-          "data-source-url": sourceurl || undefined,
+          "data-description": descriptionText || undefined,
+          "data-source": trimmedSource || undefined,
+          "data-source-url": trimmedSourceUrl || undefined,
+          "data-historical": shouldShowSource ? "true" : undefined,
         } as const;
 
     return (

--- a/src/templates/hero-photo-template.mdx
+++ b/src/templates/hero-photo-template.mdx
@@ -41,8 +41,8 @@ galleryImages:
     caption: "[HISTORICAL CAPTION]"
     seoCaption: "[HISTORICAL SEO CAPTION]"
     historical: true
-    source: "[SOURCE NAME - e.g., Image courtesy of Cornell University Library]"
-    sourceurl: "[SOURCE URL]"
+    source: "[SOURCE NAME - e.g., Image courtesy of Cornell University Library]" # OPTIONAL
+    sourceurl: "[SOURCE URL]" # OPTIONAL, plain text only
 ---
 
 import { Image } from "astro:assets";

--- a/src/templates/hero-video-template.mdx
+++ b/src/templates/hero-video-template.mdx
@@ -43,8 +43,8 @@ galleryImages:
     caption: "[HISTORICAL CAPTION]"
     seoCaption: "[HISTORICAL SEO CAPTION]"
     historical: true
-    source: "[SOURCE NAME - e.g., Image courtesy of Cornell University Library]"
-    sourceurl: "[SOURCE URL]"
+    source: "[SOURCE NAME - e.g., Image courtesy of Cornell University Library]" # OPTIONAL
+    sourceurl: "[SOURCE URL]" # OPTIONAL, plain text only
 ---
 
 import GalleryLightbox from "@/components/GalleryLightbox.astro";


### PR DESCRIPTION
## Summary
- show historical image source text (and optional source URLs) in lightbox descriptions for gallery items
- sync historical source metadata into GLightbox so captions stay non-clickable and SEO friendly
- clarify the optional historical source fields in the hero content templates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66a3c0fe8832199c3f1b06f9cd419